### PR TITLE
fix-#17 close clock while calendar display is toggled

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 .cache
 .vscode
 dist
+.idea
 coverage
 node_modules
 npm-debug.log

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-datetime-picker",
-  "version": "1.3.4",
+  "version": "1.3.5",
   "description": "A date range picker for your React app.",
   "main": "dist/entry.js",
   "es6": "src/entry.js",

--- a/src/DateTimePicker.jsx
+++ b/src/DateTimePicker.jsx
@@ -125,7 +125,10 @@ export default class DateTimePicker extends PureComponent {
   }
 
   toggleCalendar = () => {
-    this.setState(prevState => ({ isCalendarOpen: !prevState.isCalendarOpen }));
+    this.setState(prevState => ({
+      isCalendarOpen: !prevState.isCalendarOpen,
+      isClockOpen: false
+    }));
   }
 
   stopPropagation = event => event.stopPropagation();

--- a/src/__tests__/DateTimePicker.jsx
+++ b/src/__tests__/DateTimePicker.jsx
@@ -239,4 +239,20 @@ describe('DateTimePicker', () => {
     expect(component.state('isCalendarOpen')).toBe(true);
     expect(component.state('isClockOpen')).toBe(true);
   });
+
+  it('closes Clock when Calendar is opened by a click on the calendar icon', () => {
+    const component = mount(
+      <DateTimePicker isClockOpen />
+    );
+
+    expect(component.state('isClockOpen')).toBe(true);
+
+    const button = component.find('button.react-datetime-picker__calendar-button');
+    button.simulate('click');
+
+    component.update();
+
+    expect(component.state('isClockOpen')).toBe(false);
+    expect(component.find('Calendar')).toHaveLength(1)
+  })
 });


### PR DESCRIPTION
fix #17 

This PR:
* Closes the clock while the calendar display is toggled.
* Adds `.idea` to our list of ignored files.
* Bumps package version to 1.3.5