### PR TITLE
Upgrade React-Calendar to 3.0.0

### DIFF
--- a/src/DateTimePicker.jsx
+++ b/src/DateTimePicker.jsx
@@ -2,9 +2,9 @@ import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
 import makeEventProps from 'make-event-props';
 import mergeClassNames from 'merge-class-names';
+import Calendar from 'react-calendar';
 import Fit from 'react-fit';
 
-import Calendar from 'react-calendar/dist/entry.nostyle';
 import Clock from 'react-clock/dist/entry.nostyle';
 
 import DateTimeInput from './DateTimeInput';


### PR DESCRIPTION
Requires https://github.com/wojtekmaj/react-date-picker/pull/238 to be merged & released first.