### PR TITLE
Do not attempt to close the popup if a FocusEvent is send from outside.

### DIFF
--- a/src/DateTimePicker.tsx
+++ b/src/DateTimePicker.tsx
@@ -309,6 +309,7 @@ export default function DateTimePicker(props: DateTimePickerProps) {
       ) as HTMLElement;
 
       if (
+        !(event instanceof FocusEvent) &&
         target &&
         wrapperEl &&
         !wrapperEl.contains(target) &&


### PR DESCRIPTION
This targets https://github.com/wojtekmaj/react-datetime-picker/issues/56, which is still the case for Safari and the latest release if the react-datetime-picker.

The main issue is that Safari is sending two events when a day is clicked:
- click: which is for the actual click on the button element to select a day
- focus: which is send to the modal which might be inside the background

The second one will close the popup and `onChange` is never called. Other browsers does not seem to send this focus event. 
The best way to reproduce the different behaviour in the different browsers is to set a breakpoint in https://github.com/wojtekmaj/react-datetime-picker/blob/fe8494f9f05d170a16c155d3f13a7fe25706eec0/src/DateTimePicker.tsx#L311 and open/close the popup.

While the solution might not be optimal, I did not find a better way to circumvent the issue. I could not find any new regressions from this change, that said I'm not sure if I maybe missed some.

The code sandbox from https://github.com/wojtekmaj/react-datetime-picker/issues/56#issuecomment-1030321365 is the best way to reproduce it. Use the current code from this pull request as a replacement for the latest react-date time-picker release and the showcased videos will finally work as expected.

If there is anything else I can do to help to resolve this issue, maybe even in a better way, please let me know.