### PR TITLE
Add npm support metadata

### DIFF
--- a/packages/react-datetime-picker/package.json
+++ b/packages/react-datetime-picker/package.json
@@ -93,5 +93,9 @@
     "url": "git+https://github.com/wojtekmaj/react-datetime-picker.git",
     "directory": "packages/react-datetime-picker"
   },
+  "homepage": "https://github.com/wojtekmaj/react-datetime-picker/tree/main/packages/react-datetime-picker#readme",
+  "bugs": {
+    "url": "https://github.com/wojtekmaj/react-datetime-picker/issues"
+  },
   "funding": "https://github.com/wojtekmaj/react-datetime-picker?sponsor=1"
 }


### PR DESCRIPTION
## Summary

- add `homepage` metadata for the npm package
- add `bugs.url` metadata pointing to the GitHub issue tracker
- leave runtime code, dependencies, exports, and package files unchanged

## Verification

```sh
node - <<'NODE'
const fs = require('fs');
const p = JSON.parse(fs.readFileSync('packages/react-datetime-picker/package.json', 'utf8'));
if (p.homepage !== 'https://github.com/wojtekmaj/react-datetime-picker/tree/main/packages/react-datetime-picker#readme') throw new Error('missing homepage');
if (p.bugs?.url !== 'https://github.com/wojtekmaj/react-datetime-picker/issues') throw new Error('missing bugs.url');
console.log(JSON.stringify({ name: p.name, homepage: p.homepage, bugs: p.bugs }, null, 2));
NODE

git diff --check
(cd packages/react-datetime-picker && npm pack --dry-run --ignore-scripts --json)
```

Note: the dry-run pack was executed from the source checkout, so it verifies the package manifest path available in the checkout and does not rebuild release artifacts that are not present locally.
